### PR TITLE
Edit org info

### DIFF
--- a/app/views/orginfos/index.html.erb
+++ b/app/views/orginfos/index.html.erb
@@ -4,11 +4,11 @@
 <h1>Information</h1>
 </div>
 <div id="orginfos" class="center text-tile">
-  <% @orginfos.each do |orginfo| %>
-    <%= render orginfo %>
-    <p>
-      <%= link_to "View this", orginfo , class: "link-button" %>
-    </p>
+  <% if @orginfos.any? %>
+  <%= render @orginfos.first %>
+  <p>
+    <%= link_to "View this", @orginfos.first, class: "link-button" %>
+  </p>
   <% end %>
 </div>
 

--- a/app/views/orginfos/index.html.erb
+++ b/app/views/orginfos/index.html.erb
@@ -3,6 +3,7 @@
 <div class="center text-tile">
 <h1>Information</h1>
 </div>
+# Only need to render 1 org_info instance that will be edited
 <div id="orginfos" class="center text-tile">
   <% if @orginfos.any? %>
   <%= render @orginfos.first %>

--- a/spec/views/orginfos/index.html.erb_spec.rb
+++ b/spec/views/orginfos/index.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("orginfos/index", type: :view) do
   it "renders a list of orginfos" do
     render
     cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
-    assert_select cell_selector, text: Regexp.new("Title".to_s), count: 2
-    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 2
+    assert_select cell_selector, text: Regexp.new("Title".to_s), count: 1
+    assert_select cell_selector, text: Regexp.new("MyText".to_s), count: 1
   end
 end


### PR DESCRIPTION
org_info index now only renders 1 org_info instance that is edited and then displayed on landing page and dashboards.